### PR TITLE
emailを指定するとIDを返してくれる関数を追加

### DIFF
--- a/SlackAPI.js
+++ b/SlackAPI.js
@@ -4,6 +4,8 @@ class SlackAPI {
     this.channels = {};
     this.members = Array();
     this.members = this.users_list();
+    this.email2id_list = Array();
+    this.email2id_list = this.convert_users_list();
   }
   auth_test(){
     return this.post("auth.test","");
@@ -128,9 +130,21 @@ class SlackAPI {
       }else{
         return result;
       }
-      return result;
+    }
+  }
+  convert_users_list(){
+    var ret = Array();
+    if(this.email2id_list.length > 0){
+      return this.email2id_list;
     }else{
-      return -1;
+      for(var i = 0;i < this.members.length;i++){
+        var email = this.members[i]['profile']['email'];
+        ret[i] = {
+                  email:this.members[i]['profile']['email'],
+                  id:this.members[i]['id']
+                  };
+      }
+      return ret;
     }
   }
   user_name2id(user_name){

--- a/SlackAPI.js
+++ b/SlackAPI.js
@@ -2,6 +2,7 @@ class SlackAPI {
   constructor(token){
     this.token = token;
     this.channels = {};
+    this.members = Array();
     this.members = this.users_list();
   }
   auth_test(){
@@ -109,14 +110,23 @@ class SlackAPI {
     var api1 = "users";
     var api2 = "list";
     var data_name = "members";
-    var list = JSON.parse(this.post(api1 + "." + api2,options));
-    var result = Array();
-    if(list["ok"] == true){
-      result = result.concat(list[data_name])
-      while(Object.keys(list).indexOf('response_metadata') !== -1 && Object.keys(list.response_metadata).indexOf('next_cursor') !== -1 && list.response_metadata.next_cursor.length > 1){
-        options['cursor'] = list["response_metadata"]["next_cursor"];
-        list = JSON.parse(this.post(api1 + "."+ api2,options));
-        result = result.concat(list[data_name])
+    // すでにthis.membersが設定されていたらAPIにアクセスしない
+    if(this.members.length > 0){
+       return this.members;
+    }else{
+      var result = this.post(api1 + "." + api2,options);
+      var list = JSON.parse(result);
+      var ret = Array();
+      if(list["ok"] == true){
+        ret = ret.concat(list[data_name])
+        while(Object.keys(list).indexOf('response_metadata') !== -1 && Object.keys(list.response_metadata).indexOf('next_cursor') !== -1 && list.response_metadata.next_cursor.length > 1){
+          options['cursor'] = list["response_metadata"]["next_cursor"];
+          list = JSON.parse(this.post(api1 + "."+ api2,options));
+          ret = ret.concat(list[data_name]);
+        }
+        return ret;
+      }else{
+        return result;
       }
       return result;
     }else{

--- a/SlackAPI.js
+++ b/SlackAPI.js
@@ -147,12 +147,17 @@ class SlackAPI {
       return ret;
     }
   }
-  user_name2id(user_name){
-    this.users = this.users_list();
-    for(var i in this.users){
-      if(this.users[i]['name'] == user_name){
-        return this.users[i]['id'];
+  email2userid(email){
+    var list = this.email2id_list;
+    var target = list.find(function(user){
+      if(user.email == email){
+        return(user);
       }
+    });
+    if(target.length == 0){
+      return -1;
+    }else{
+      return target.id;
     }
     return -1;
   }


### PR DESCRIPTION
###  users_list
SlackAPIにアクセスしてユーザの一覧をとってきて this.membersに入れる。
this.membersに何かが設定されていたらAPIにアクセスしないでthis.membersを返す
(this.membersは長さしかチェックしてない(中身もチェックしないと駄目）

### convert_users_list
this.membersは難しいので、{email: "メールアドレス",id: "SlackのID"} の入った配列に変換してthis.email2id_listに入れる。
this.email2id_listの長さが0じゃなければ何もしないでthis.email2id_listをそのまま返す

### email2userid(email)
指定されたメールアドレスに登録されているユーザのSlackの内部IDを返す